### PR TITLE
Scriptutil updates

### DIFF
--- a/js/heslog.js
+++ b/js/heslog.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const util = require('./hesutil');
+const scriptutil = require('./scriptutil');
 
 const HESLOG_KEY = "library.nd.edu.logger";
 
@@ -16,8 +17,8 @@ LEVELS[LEVEL_DEBUG] = "DEBUG";
 LEVELS[LEVEL_VERBOSE] = "VERBOSE";
 LEVELS[LEVEL_TEST] = "TEST";
 LEVELS[LEVEL_INFO] = "INFO";
-LEVELS[LEVEL_WARN] = "WARN";
-LEVELS[LEVEL_ERROR] = "ERROR";
+LEVELS[LEVEL_WARN] = scriptutil.format("WARN", scriptutil.FG_LIGHT_YELLOW);
+LEVELS[LEVEL_ERROR] = scriptutil.format("ERROR", scriptutil.FG_RED);
 
 // grock
 // LEVELS (DEBUG|TEST|VERBOSE|INFO||WARN|ERROR)

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hesburgh_util",
   "description": "Hesburgh Javascript Utilities",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "license": "Apache 2.0",
   "main": "index.js",
   "author": "Harrison Beachey <hbeachey@nd.edu>",

--- a/js/scriptutil.js
+++ b/js/scriptutil.js
@@ -1,0 +1,185 @@
+const hesutil = require('./hesutil')
+
+const FG_DEFAULT = 39
+const FG_BLACK = 30
+const FG_RED = 31
+const FG_GREEN = 32
+const FG_YELLOW = 33
+const FG_BLUE = 34
+const FG_MAGENTA = 35
+const FG_CYAN = 36
+const FG_LIGHT_GRAY = 37
+const FG_DARK_GRAY = 90
+const FG_LIGHT_RED = 91
+const FG_LIGHT_GREEN = 92
+const FG_LIGHT_YELLOW = 93
+const FG_LIGHT_BLUE = 94
+const FG_LIGHT_MAGENTA = 95
+const FG_LIGHT_CYAN = 96
+const FG_WHITE = 97
+
+const FG_COLORS = [
+  FG_DEFAULT,
+  FG_BLACK,
+  FG_RED,
+  FG_GREEN,
+  FG_YELLOW,
+  FG_BLUE,
+  FG_MAGENTA,
+  FG_CYAN,
+  FG_LIGHT_GRAY,
+  FG_DARK_GRAY,
+  FG_LIGHT_RED,
+  FG_LIGHT_GREEN,
+  FG_LIGHT_YELLOW,
+  FG_LIGHT_BLUE,
+  FG_LIGHT_MAGENTA,
+  FG_LIGHT_CYAN,
+  FG_WHITE,
+]
+
+const BG_DEFAULT = 49
+const BG_BLACK = 40
+const BG_RED = 41
+const BG_GREEN = 42
+const BG_YELLOW = 43
+const BG_BLUE = 44
+const BG_MAGENTA = 45
+const BG_CYAN = 46
+const BG_LIGHT_GRAY = 47
+const BG_DARK_GRAY = 100
+const BG_LIGHT_RED = 101
+const BG_LIGHT_GREEN = 102
+const BG_LIGHT_YELLOW = 103
+const BG_LIGHT_BLUE = 104
+const BG_LIGHT_MAGENTA = 105
+const BG_LIGHT_CYAN = 106
+const BG_WHITE = 107
+
+const BG_COLORS = [
+  BG_DEFAULT,
+  BG_BLACK,
+  BG_RED,
+  BG_GREEN,
+  BG_YELLOW,
+  BG_BLUE,
+  BG_MAGENTA,
+  BG_CYAN,
+  BG_LIGHT_GRAY,
+  BG_DARK_GRAY,
+  BG_LIGHT_RED,
+  BG_LIGHT_GREEN,
+  BG_LIGHT_YELLOW,
+  BG_LIGHT_BLUE,
+  BG_LIGHT_MAGENTA,
+  BG_LIGHT_CYAN,
+  BG_WHITE,
+]
+
+const BOLD = 1
+const DIM = 2
+const UNDERLINE = 4
+
+const EXTRA_FORMATS = [
+  BOLD,
+  DIM,
+  UNDERLINE,
+]
+
+const ALL_FORMATS = FG_COLORS.concat(BG_COLORS, EXTRA_FORMATS)
+
+function _prefix() {
+  return "\x1B["
+}
+
+// tput colors
+const _term_colors = !hesutil.onAWS
+// This method wraps the requested terminal color codes around the given message
+function format() {
+  if (arguments.length === 0) {
+    return null
+  }
+
+  let text = arguments[0]
+  if (!_term_colors || arguments.length === 1) {
+    return text
+  }
+
+  const reset = _prefix() + "0m"
+
+  let fmt = _prefix()
+  for (let index in arguments) {
+    if (index === "0") {
+      continue
+    }
+    let arg = arguments[index]
+    if (!ALL_FORMATS.includes(arg)) {
+      return error(arg + " is not a text format code")
+    }
+    fmt += `;${arg}`
+  }
+  fmt += `m${text}${reset}`
+  return fmt
+}
+
+
+function success(text) {
+  return format(text, FG_GREEN)
+}
+
+function error(text) {
+  return format(text, FG_RED)
+}
+
+module.exports = {
+  FG_DEFAULT,
+  FG_BLACK,
+  FG_RED,
+  FG_GREEN,
+  FG_YELLOW,
+  FG_BLUE,
+  FG_MAGENTA,
+  FG_CYAN,
+  FG_LIGHT_GRAY,
+  FG_DARK_GRAY,
+  FG_LIGHT_RED,
+  FG_LIGHT_GREEN,
+  FG_LIGHT_YELLOW,
+  FG_LIGHT_BLUE,
+  FG_LIGHT_MAGENTA,
+  FG_LIGHT_CYAN,
+  FG_WHITE,
+
+  FG_COLORS,
+
+  BG_DEFAULT,
+  BG_BLACK,
+  BG_RED,
+  BG_GREEN,
+  BG_YELLOW,
+  BG_BLUE,
+  BG_MAGENTA,
+  BG_CYAN,
+  BG_LIGHT_GRAY,
+  BG_DARK_GRAY,
+  BG_LIGHT_RED,
+  BG_LIGHT_GREEN,
+  BG_LIGHT_YELLOW,
+  BG_LIGHT_BLUE,
+  BG_LIGHT_MAGENTA,
+  BG_LIGHT_CYAN,
+  BG_WHITE,
+
+  BG_COLORS,
+
+  BOLD,
+  DIM,
+  UNDERLINE,
+
+  EXTRA_FORMATS,
+  ALL_FORMATS,
+
+  format,
+  success,
+  error,
+}

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -3,6 +3,7 @@
 const heslog = require('../heslog');
 const hesutil = require('../hesutil');
 const hestest = require('../hestest');
+const script = require('../scriptutil')
 
 var foo = { foo: {bar: "baz"}}
 hesutil.dictGet(foo, "foo").safeGet("bar")

--- a/makeVersion.sh
+++ b/makeVersion.sh
@@ -1,0 +1,11 @@
+
+pushd py
+# set version first
+  python setup.py bdist_wheel
+  twine upload dist/*
+popd
+
+pushd js
+# set version first
+  npm publish
+popd

--- a/py/hesburgh/heslog.py
+++ b/py/hesburgh/heslog.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import inspect
 
 import hesutil
+import scriptutil
 
 LEVEL_DEBUG   = 0
 LEVEL_VERBOSE = 3
@@ -15,8 +16,8 @@ LEVELS = {
   LEVEL_VERBOSE: "VERBOSE",
   LEVEL_TEST: "TEST",
   LEVEL_INFO: "INFO",
-  LEVEL_WARN: "WARN",
-  LEVEL_ERROR: "ERROR",
+  LEVEL_WARN: scriptutil.format("WARN", scriptutil.FG_LIGHT_YELLOW),
+  LEVEL_ERROR: scriptutil.format("ERROR", scriptutil.FG_RED),
 }
 
 # grock
@@ -43,7 +44,7 @@ class Logger(object):
 
 
     def _log(self, message):
-      print message
+      scriptutil.write(message)
 
 
     def _getPrefix(self, level):
@@ -57,13 +58,14 @@ class Logger(object):
     def _format(self, message, **kwargs):
       coreCopy = self.coreContext.copy()
       coreCopy.update(kwargs)
+      out = u""
       if coreCopy:
-        out = u""
         for k,v in coreCopy.iteritems():
           out += u"%s=%s | " % (k,v)
+      if hesutil.onAWS:
         out += u"message=%s" % (message)
       else:
-        out = u"message=%s" % message
+        out += u"%s" % (message)
       return out
 
 

--- a/py/hesburgh/scriptutil.py
+++ b/py/hesburgh/scriptutil.py
@@ -88,11 +88,13 @@ EXTRA_FORMATS = [
 
 ALL_FORMATS = FG_COLORS + BG_COLORS + EXTRA_FORMATS
 
+
 def _prefix():
   return "\x1B["
 
 # tput colors
 _term_colors = not hesutil.onAWS
+# This method wraps the requested terminal color codes around the given message
 def format(text, *args):
   if not _term_colors:
     return text
@@ -114,4 +116,52 @@ def success(text):
 
 def error(text):
   return format(text, FG_RED)
+
+
+def userInput(message):
+  return raw_input("\n%s\n>> " % message)
+
+
+# returns false if message doesn't uniquely denote an item in the options list
+# eg 'y' uniquely denotes 'yes' in the options ['yes', 'no'] but nothing in ['young', 'yellow']
+def isValidInput(message, options):
+  validOptions = options
+  # iterate through each letter
+  for index in xrange(len(message)):
+    if len(validOptions) == 0:
+      return False
+
+    letter = message[index]
+
+    tmpOptions = []
+    # check this letter index in every valid option, remove those that don't match from valid options
+    for option in validOptions:
+      if len(option) > index and option[index] == letter:
+        tmpOptions.append(option)
+    validOptions = tmpOptions
+
+  if len(validOptions) != 1:
+    return False
+
+  return validOptions[0]
+
+
+def getValidInput(message, options):
+  valid = False
+  while not valid:
+    data = userInput(message)
+    valid = isValidInput(data, options)
+
+  return valid
+
+
+def isTruthy(text):
+  text = text.lower()
+  return isValidInput(text, ["yes"])
+
+# this method exists so we can conditionally change where we write to in the future
+#  for instance, an interactive terminal instead of just a normal stdout
+def write(msg):
+  # if not hesutil.onAWS:
+  print msg
 

--- a/py/hesburgh/test/scriptTest.py
+++ b/py/hesburgh/test/scriptTest.py
@@ -1,31 +1,31 @@
-from hesburgh import scriptText
+from hesburgh import scriptutil
 
 text = ""
-for bg in scriptText.BG_COLORS:
-  text += scriptText.format("bg", bg)
+for bg in scriptutil.BG_COLORS:
+  text += scriptutil.format("bg", bg)
 
 print text
 text = ""
 
-for fg in scriptText.FG_COLORS:
-  text += scriptText.format("fg", fg)
+for fg in scriptutil.FG_COLORS:
+  text += scriptutil.format("fg", fg)
 
 print text
 text = ""
 
-for extra in scriptText.EXTRA_FORMATS:
-  text += scriptText.format("extra", extra)
+for extra in scriptutil.EXTRA_FORMATS:
+  text += scriptutil.format("extra", extra)
 
 print text
 text = ""
 
-for fg in scriptText.FG_COLORS:
-  for bg in scriptText.BG_COLORS:
-    text += scriptText.format("fgbg", fg, bg)
-    for extra in scriptText.EXTRA_FORMATS:
-      text += scriptText.format("all", fg, bg, extra)
+for fg in scriptutil.FG_COLORS:
+  for bg in scriptutil.BG_COLORS:
+    text += scriptutil.format("fgbg", fg, bg)
+    for extra in scriptutil.EXTRA_FORMATS:
+      text += scriptutil.format("all", fg, bg, extra)
   print text
   text = ""
 
-print scriptText.success("win!")
-print scriptText.error("lose!")
+print scriptutil.success("win!")
+print scriptutil.error("lose!")

--- a/py/setup.py
+++ b/py/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.0.2',
 
     description='Hesburgh Libraries Utility Modules',
     # long_description=long_description,

--- a/testdata/accounts.json
+++ b/testdata/accounts.json
@@ -5,6 +5,7 @@
     "mvanneve",
     "jgondron",
     "rfox2",
+    "rdought1",
 
     "t_heslib01",
     "t_heslib02",


### PR DESCRIPTION
scriptutil is a util library that mainly provides color output functionality, but also some input and validation helpers

- Ported scriptutil color formatting to js
- added input and text validation functions to scriptutil.py
- changed heslog to use color output when not on aws for `error` and `warn` messages