### PR TITLE
Deploy Updates

### DIFF
--- a/scripts/lifecycle.py
+++ b/scripts/lifecycle.py
@@ -87,6 +87,20 @@ class Lifecycle(object):
     if not self.args.noAws:
       self.cfClient = boto3.client('cloudformation')
 
+    # since we must pass cloudformatino a role to use
+    #   we need the current account id (since the role name is static)
+    self.accountId = self.getAccountId()
+
+
+  def getAccountId(self):
+    client = boto3.client('sts')
+    try:
+      response = client.get_caller_identity()
+      return response.get("Account")
+    except Exception as e:
+      heslog.error(e)
+      raise Abort("Couldn't get assumed role account")
+
 
   def confirm(self, message):
     if self.args.yes:
@@ -316,6 +330,9 @@ class Lifecycle(object):
       "Parameters": params,
       "Capabilities": stackConfig.get("capabilities"),
       "Tags": tags,
+      # Tell cloudformation to use this role to do the deployment
+      #   the name is static accross accounts, so just sub in the current account id
+      "RoleARN": "arn:aws:iam::%s:role/wse/service-role/lib-developer-cf-servicerole" % self.accountId,
     }
     heslog.verbose("Stack args %s" % stackArgs)
     return stackArgs
@@ -443,7 +460,7 @@ class Lifecycle(object):
     heslog.addContext(stage="postDeploy")
     outputs = {}
     # If we deleted the stacks, don't retrieve non-existant outputs
-    if not self.args.noAws and self.stackAction.get("key") != "delete":
+    if not self.args.noAws:
       # describe all the stacks so we can pass info to post
       for stackConfig in self.config.stacks():
         name = stackConfig.get("name")
@@ -532,7 +549,7 @@ class Lifecycle(object):
         return
 
 
-  def selectStageTouse(self, stages):
+  def selectStageToUse(self, stages):
     if len(stages) <= 0:
       heslog.info("No stages found for %s" % self.config.serviceName())
       return self._inputNewStage()
@@ -561,6 +578,15 @@ class Lifecycle(object):
 
   def setStepsToRun(self):
     varArgs = vars(self.args)
+
+    # if we're deleting the stack, just run pre and delete
+    #   no other steps matter (pre might set a required env var)
+    if varArgs.get("delete"):
+      self.chooseStackAction()
+      if not varArgs.noPre:
+        self.steps.append('pre')
+      return
+
     # determine if we are limiting the steps because some were specified
     for s in self.deploymentStepOrder:
       stepName = s.get("key")
@@ -573,10 +599,8 @@ class Lifecycle(object):
     if not isExlusive:
       for s in self.deploymentStepOrder:
         # check to see if this step was excluded
-        if not varArgs.get("no%s" % s.get("key").title()):
+        if not varArgs.get("no%s" % s.get("key").title()) and s.get("key") != self.stackFnKey:
           self.steps.append(s.get("key"))
-
-    self.chooseStackAction()
 
     heslog.debug("running steps %s" % self.steps)
 
@@ -616,12 +640,15 @@ class Lifecycle(object):
             self.steps.append(self.stackFnKey)
           break
 
+      if self.stackFnKey not in self.steps:
+        heslog.info("No stack action [create, update, delete, replace] was passed")
+
 
   # Run the entire deployment
   def run(self):
     try:
       # Make sure we assumed a role if needed
-      if not self.args.noAws and not hesutil.getEnv("AWS_ROLE_ARN"):
+      if not self.args.noAws and not hesutil.getEnv("AWS_SESSION_TOKEN"):
         heslog.error("When 'noAws' has not been specified you must assume a role to run this script")
         raise Abort('No Assumed Role')
 
@@ -645,10 +672,10 @@ class Lifecycle(object):
 
       if not self.args.noAws:
         # If we don't have a stage, prompt user to select an existing one or create a new one
-        if not self.args.stage and self.stackFnKey in self.steps:
-          self.selectStageTouse(stages)
-          # Need to update the stack action after choosing a stage
-          self.chooseStackAction()
+        if not self.args.stage:
+          self.selectStageToUse(stages)
+
+        self.chooseStackAction()
 
         # confirm stack action on stage
         if self.stackFnKey in self.steps:


### PR DESCRIPTION
To deploy we must assume a role in the given account. That assumed role doesn't have permission to actually interact with AWS services other than Cloudformation. Thus, we must pass cloudformation a "service role" for it to use so it has permission to create/update/delete other infrastructure.

This update implements what's described above, as well as some other small changes
- `--delete` will no longer try to do all steps (package, publish, etc), only the `preDeploy` step will be included and `--noPre` can override
- passing no stack action `[create, delete, update, replace]` gives a more informative log message
- if no stage was passed, and you are hitting AWS, always prompt for what stage to use - this may not always be desirable (for instance, when only executing the `preDeploy` and/or `package` step(s)), but in most common cases it is